### PR TITLE
chore: add note about az openai regions

### DIFF
--- a/website/docs/azure-content-safety/lab2-create-content-safety/lab2-create-content-safety.md
+++ b/website/docs/azure-content-safety/lab2-create-content-safety/lab2-create-content-safety.md
@@ -42,6 +42,7 @@ Otherwise, run the following command.
 ```shell
 az deployment group create --name rai-workshop --template-file use-openai/main.bicep 
 ```
+> Note: Currently, Azure OpenAI Service is only available in [certain regions](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?products=cognitive-services&WT.mc_id=studentamb_118941).
 7. See the environment variables for your resources.
 ```shell
 bash setenv.sh


### PR DESCRIPTION
The current tutorial does not provide any info about available regions for Azure OpenAI and executing  `az deployment group create --name rai-workshop --template-file no-openai/main.bicep ` fails when choosing one of unavailable regions.

While I plan to make another PR to update [main.bicep](https://github.com/Azure-Samples/rai-content-safety-workshop/blob/764b8012dae555231747d98107e7d8581e91dbba/use-openai/main.bicep#L37) from the [workshop repo](https://github.com/Azure-Samples/rai-content-safety-workshop), I believe this tutorial should have a note about this.

What I found interesting is that [this page](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?products=cognitive-services&WT.mc_id=studentamb_118941) does not provide accurate information. It says Azure OpenAI Service can be deployed in South Central while that is not true as shown in [this issue](https://github.com/Azure-Samples/rai-content-safety-workshop/issues/1). So, maybe it wouldn't be enough to just point to the page. That is why I will make another PR to remove those regions from bicep.main as well.